### PR TITLE
Feature: multi-axis-rotation for older Minecraft versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Puzzle v2.3.0
+- Backported Minecraft 1.21.11's new multi-axis-rotation system for models to MC 1.20.1 - 1.21.10
+
 ## Puzzle v2.2.1
 - Add support for 1.21.11 (Mounts of Mayhem)
 - Fix crash when ModMenu is missing

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=false
 #org.gradle.configureondemand=true
 
 # Mod properties
-mod.version=2.2.1
+mod.version=2.3.0
 mod.group=eu.midnightdust
 mod.id=puzzle
 mod.name=Puzzle

--- a/src/main/java/net/puzzlemc/models/MultiAxisRotation.java
+++ b/src/main/java/net/puzzlemc/models/MultiAxisRotation.java
@@ -1,0 +1,11 @@
+package net.puzzlemc.models;
+
+//? if < 1.21.11 {
+/*import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+
+public interface MultiAxisRotation {
+    void puzzle$setMultiAxisRotation(Vector3f rotation);
+    @Nullable Vector3f puzzle$getMultiAxisRotation();
+}
+*///?}

--- a/src/main/java/net/puzzlemc/models/mixin/MixinBlockElementRotation.java
+++ b/src/main/java/net/puzzlemc/models/mixin/MixinBlockElementRotation.java
@@ -27,8 +27,9 @@ public class MixinBlockElementRotation implements MultiAxisRotation {
     }
 }
 *///?} else {
+import org.spongepowered.asm.mixin.Mixin;
 import eu.midnightdust.core.MidnightLib;
 
 @Mixin(MidnightLib.class)
-public abstract class MixinFaceBakery {}
+public abstract class MixinBlockElementRotation {}
 //?}

--- a/src/main/java/net/puzzlemc/models/mixin/MixinBlockElementRotation.java
+++ b/src/main/java/net/puzzlemc/models/mixin/MixinBlockElementRotation.java
@@ -1,0 +1,34 @@
+package net.puzzlemc.models.mixin;
+
+//? if < 1.21.11 {
+/*import net.minecraft.client.renderer.block.model.BlockElementRotation;
+import net.puzzlemc.models.MultiAxisRotation;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(BlockElementRotation.class)
+public class MixinBlockElementRotation implements MultiAxisRotation {
+    @Nullable
+    @Unique
+    public Vector3f multiAxisRotation = null;
+
+    @Override
+    @Unique
+    public void puzzle$setMultiAxisRotation(Vector3f rotation) {
+        this.multiAxisRotation = rotation;
+    }
+
+    @Override
+    @Unique
+    public @Nullable Vector3f puzzle$getMultiAxisRotation() {
+        return this.multiAxisRotation;
+    }
+}
+*///?} else {
+import eu.midnightdust.core.MidnightLib;
+
+@Mixin(MidnightLib.class)
+public abstract class MixinFaceBakery {}
+//?}

--- a/src/main/java/net/puzzlemc/models/mixin/MixinFaceBakery.java
+++ b/src/main/java/net/puzzlemc/models/mixin/MixinFaceBakery.java
@@ -1,0 +1,98 @@
+package net.puzzlemc.models.mixin;
+
+//? if < 1.21.11 {
+/*import net.minecraft.client.renderer.block.model.BlockElementRotation;
+import net.minecraft.client.renderer.block.model.FaceBakery;
+import net.minecraft.core.Direction;
+import net.puzzlemc.models.MultiAxisRotation;
+import org.joml.Math;
+import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FaceBakery.class)
+public abstract class MixinFaceBakery {
+    @Inject(method = "applyElementRotation", at = @At("HEAD"), cancellable = true)
+    private void puzzle$applyMultiAxisRotation(Vector3f vector3f, BlockElementRotation rotationInfo, CallbackInfo ci) {
+       //noinspection ConstantValue
+       if (rotationInfo != null && ((MultiAxisRotation) (Object) rotationInfo).puzzle$getMultiAxisRotation() != null) {
+           puzzle$rotateVertexBy(vector3f, rotationInfo.origin(), puzzle$calcRotationMatrix(rotationInfo));
+           ci.cancel();
+       }
+    }
+
+    @Unique
+    private Matrix4f puzzle$calcRotationMatrix(BlockElementRotation arg) {
+        Matrix4f matrix4f = puzzle$getTransformation(arg);
+        if (arg.rescale() && !puzzle$isIdentityMatrix(matrix4f))
+            matrix4f.scale(puzzle$calcRescale(matrix4f));
+
+        return matrix4f;
+    }
+
+    @Unique
+    private static Vector3fc puzzle$calcRescale(Matrix4fc modelMatrix) {
+        Vector3f vector3f = new Vector3f();
+        float scaleX = puzzle$scaleFactorForAxis(modelMatrix, Direction.Axis.X, vector3f);
+        float scaleY = puzzle$scaleFactorForAxis(modelMatrix, Direction.Axis.Y, vector3f);
+        float scaleZ = puzzle$scaleFactorForAxis(modelMatrix, Direction.Axis.Z, vector3f);
+        return vector3f.set(scaleX, scaleY, scaleZ);
+    }
+
+    @Unique
+    private static Vector3f puzzle$getUnitVec3f(Direction.Axis axis) {
+        Direction dir = switch (axis) {
+            case X -> Direction.EAST;
+            case Y -> Direction.UP;
+            case Z -> Direction.SOUTH;
+        };
+        return dir.step();
+    }
+
+    @Unique
+    private static float puzzle$scaleFactorForAxis(Matrix4fc modelMatrix, Direction.Axis axis, Vector3f vector3f) {
+        Vector3f scaleVector = modelMatrix.transformDirection(vector3f.set(puzzle$getUnitVec3f(axis)));
+        float maxDimension = Math.max(Math.max(Math.abs(scaleVector.x), Math.abs(scaleVector.y)), Math.abs(scaleVector.z));
+        return 1.0F / maxDimension;
+    }
+
+    @Unique
+    public Matrix4f puzzle$getTransformation(BlockElementRotation rotation) {
+        Vector3f perAxisRotation = ((MultiAxisRotation)(Object)rotation).puzzle$getMultiAxisRotation();
+        assert perAxisRotation != null;
+        return (new Matrix4f()).rotationZYX(perAxisRotation.z * ((float)Math.PI / 180F),
+                perAxisRotation.y * ((float)Math.PI / 180F),
+                perAxisRotation.x * ((float)Math.PI / 180F));
+    }
+
+    @Unique
+    private static void puzzle$rotateVertexBy(Vector3f vertexPos, Vector3fc rotationOrigin, Matrix4fc rotationMatrix) {
+        vertexPos.sub(rotationOrigin);
+        rotationMatrix.transformPosition(vertexPos);
+        vertexPos.add(rotationOrigin);
+    }
+
+    @Unique
+    private static boolean puzzle$isIdentityMatrix(Matrix4fc matrix) {
+        if ((matrix.properties() & 4) != 0)
+            return true;
+
+        if (matrix instanceof Matrix4f matrix4f) {
+            matrix4f.determineProperties();
+            return (matrix4f.properties() & 4) != 0;
+        }
+        return false;
+    }
+}
+*///?} else {
+import eu.midnightdust.core.MidnightLib;
+
+@Mixin(MidnightLib.class)
+public abstract class MixinFaceBakery {}
+//?}

--- a/src/main/java/net/puzzlemc/models/mixin/MixinFaceBakery.java
+++ b/src/main/java/net/puzzlemc/models/mixin/MixinFaceBakery.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(FaceBakery.class)
 public abstract class MixinFaceBakery {
     @Inject(method = "applyElementRotation", at = @At("HEAD"), cancellable = true)
-    private void puzzle$applyMultiAxisRotation(Vector3f vector3f, BlockElementRotation rotationInfo, CallbackInfo ci) {
+    private /^? if >= 1.21.4 {^/ static /^?}^/ void puzzle$applyMultiAxisRotation(Vector3f vector3f, BlockElementRotation rotationInfo, CallbackInfo ci) {
        //noinspection ConstantValue
        if (rotationInfo != null && ((MultiAxisRotation) (Object) rotationInfo).puzzle$getMultiAxisRotation() != null) {
            puzzle$rotateVertexBy(vector3f, rotationInfo.origin(), puzzle$calcRotationMatrix(rotationInfo));
@@ -28,7 +28,7 @@ public abstract class MixinFaceBakery {
     }
 
     @Unique
-    private Matrix4f puzzle$calcRotationMatrix(BlockElementRotation arg) {
+    private static Matrix4f puzzle$calcRotationMatrix(BlockElementRotation arg) {
         Matrix4f matrix4f = puzzle$getTransformation(arg);
         if (arg.rescale() && !puzzle$isIdentityMatrix(matrix4f))
             matrix4f.scale(puzzle$calcRescale(matrix4f));
@@ -63,7 +63,7 @@ public abstract class MixinFaceBakery {
     }
 
     @Unique
-    public Matrix4f puzzle$getTransformation(BlockElementRotation rotation) {
+    private static Matrix4f puzzle$getTransformation(BlockElementRotation rotation) {
         Vector3f perAxisRotation = ((MultiAxisRotation)(Object)rotation).puzzle$getMultiAxisRotation();
         assert perAxisRotation != null;
         return (new Matrix4f()).rotationZYX(perAxisRotation.z * ((float)Math.PI / 180F),
@@ -91,6 +91,7 @@ public abstract class MixinFaceBakery {
     }
 }
 *///?} else {
+import org.spongepowered.asm.mixin.Mixin;
 import eu.midnightdust.core.MidnightLib;
 
 @Mixin(MidnightLib.class)

--- a/src/main/java/net/puzzlemc/models/mixin/MixinModelElementDeserializer.java
+++ b/src/main/java/net/puzzlemc/models/mixin/MixinModelElementDeserializer.java
@@ -10,13 +10,37 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-//? if < 1.21.11
-/*import net.minecraft.util.GsonHelper;*/
+//? if < 1.21.11 {
+/*import net.minecraft.util.GsonHelper;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.renderer.block.model.BlockElementRotation;
+import net.minecraft.core.Direction;
+import net.puzzlemc.models.MultiAxisRotation;
+*///?}
 
 @Mixin(BlockElement.Deserializer.class)
 public abstract class MixinModelElementDeserializer {
     //? if < 1.21.11 {
     /*@Shadow protected abstract Vector3f getVector3f(JsonObject jsonObject, String string);
+
+    @Inject(method = "getRotation", at = @At(value = "INVOKE", target = "Lorg/joml/Vector3f;mul(F)Lorg/joml/Vector3f;", shift = At.Shift.AFTER), cancellable = true)
+    private void getRotation(JsonObject jsonObject, CallbackInfoReturnable<BlockElementRotation> cir, @Local Vector3f vector3f) {
+        JsonObject rotationData = GsonHelper.getAsJsonObject(jsonObject, "rotation");
+        if (PuzzleConfig.unlimitedRotations && !rotationData.has("angle") && !rotationData.has("axis")) {
+            if (!rotationData.has("x") && !rotationData.has("y") && !rotationData.has("z")) {
+                throw new JsonParseException("Missing rotation value, expected either 'axis' and 'angle' or 'x', 'y' and 'z'");
+            }
+
+            float xRot = GsonHelper.getAsFloat(rotationData, "x", 0.0F);
+            float yRot = GsonHelper.getAsFloat(rotationData, "y", 0.0F);
+            float zRot = GsonHelper.getAsFloat(rotationData, "z", 0.0F);
+
+            boolean shouldRescale = GsonHelper.getAsBoolean(rotationData, "rescale", false);
+            BlockElementRotation rotation = new BlockElementRotation(vector3f, Direction.Axis.Z, 0.0F, shouldRescale);
+            ((MultiAxisRotation) (Object) rotation).puzzle$setMultiAxisRotation(new Vector3f(xRot, yRot, zRot)); // Adds the per-axis rotation values to the BlockElementRotation object
+            cir.setReturnValue(rotation);
+        }
+    }
 
     @Inject(at = @At("HEAD"),method = "getAngle", cancellable = true)
     private void puzzle$deserializeRotationAngle(JsonObject object, CallbackInfoReturnable<Float> cir) {

--- a/src/main/resources/puzzle-models.mixins.json
+++ b/src/main/resources/puzzle-models.mixins.json
@@ -3,6 +3,8 @@
   "package": "net.puzzlemc.models.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "MixinBlockElementRotation",
+    "MixinFaceBakery",
     "MixinModelElementDeserializer"
   ],
   "injectors": {


### PR DESCRIPTION
- Backported Minecraft 1.21.11's new multi-axis-rotation system for models to MC 1.20.1–1.21.10